### PR TITLE
feature/remove full rd enum

### DIFF
--- a/src/bitmovin-dotnet/Codec/H264VideoConfigurationFactory.cs
+++ b/src/bitmovin-dotnet/Codec/H264VideoConfigurationFactory.cs
@@ -170,7 +170,7 @@ namespace com.bitmovin.Api.Codec
                         Cabac = true,
                         RcLookahead = 60,
                         RefFrames = 16,
-                        SubMe = H264SubMe.FULL_RD,
+                        SubMe = H264SubMe.QPRD,
                         Trellis = H264Trellis.ENABLED_ALL,
                         Partitions = new List<H264Partition> { H264Partition.ALL }
                     };

--- a/src/bitmovin-dotnet/Enums/H264SubMe.cs
+++ b/src/bitmovin-dotnet/Enums/H264SubMe.cs
@@ -12,7 +12,6 @@
         RD_ALL,
         RD_REF_IP,
         RD_REF_ALL,
-        QPRD,
-        FULL_RD
+        QPRD
     }
 }


### PR DESCRIPTION
FULL_RD slows down H264 encodes by 40% and does not improve quality.